### PR TITLE
Add Makefile for convenient theme packing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+PROJECT=anarchy-wp-theme
+TARGET="$(PROJECT)-$(shell date +%F-%H%M%S)-git$(shell git describe --always).zip"
+PWD=$(shell pwd)
+PREFIX=./www/wp-content/themes
+
+$(TARGET):
+	@echo "  ZIP $@"
+	@cd $(PREFIX) && zip $(PWD)/$@ -r anarchy > /dev/null


### PR DESCRIPTION
Just run
 make
inside the root repo dir and you'll get wordpress theme zip archive
with a name like anarchy-wp-theme-2015-04-16-232721-git9144285.zip
which you can simply upload to your wordpress installation via the
web-interface
